### PR TITLE
Update labix.org/v2/mgo dependency to gopkg.in/mgo.v2

### DIFF
--- a/helpers/auth.go
+++ b/helpers/auth.go
@@ -1,8 +1,8 @@
 package helpers
 
 import (
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"code.google.com/p/go.crypto/bcrypt"
 	"github.com/elcct/defaultproject/models"
 )

--- a/models/user.go
+++ b/models/user.go
@@ -1,8 +1,8 @@
 package models
 
 import (
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 	"code.google.com/p/go.crypto/bcrypt"
 	"github.com/golang/glog"
 	"time"

--- a/system/controller.go
+++ b/system/controller.go
@@ -3,7 +3,7 @@ package system
 import (
 	"bytes"
 	"html/template"
-	"labix.org/v2/mgo"
+	mgo "gopkg.in/mgo.v2"
 	"github.com/zenazn/goji/web"
 	"github.com/gorilla/sessions"
 )

--- a/system/core.go
+++ b/system/core.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gorilla/sessions"
 
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 
 	"html/template"
 

--- a/system/middleware.go
+++ b/system/middleware.go
@@ -7,8 +7,8 @@ import (
 	"github.com/elcct/defaultproject/models"
 	"github.com/gorilla/context"
 	"github.com/gorilla/sessions"
-	"labix.org/v2/mgo"
-	"labix.org/v2/mgo/bson"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // Makes sure templates are stored in the context


### PR DESCRIPTION
labix.org/v2/mgo is still using bzr, switch to gokpg.in/mgo.v2 
